### PR TITLE
feat: split certificates into a new stack in us-east-1

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -1,11 +1,28 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
+
+import { CertStack } from '../lib/cert-stack';
 import { HomepageStack } from '../lib/homepage-stack';
 
 const app = new cdk.App();
-new HomepageStack(app, 'HomepageStack', {
+
+const tags = cdk.Tags.of(app);
+tags.add('app', 'Homepage');
+tags.add('repo', 'https://github.com/viet-aus-it/homepage');
+
+const certStack = new CertStack(app, 'HomepageCertStack', {
+  env: {
+    account: process.env.AWS_ACCOUNT_ID,
+    region: 'us-east-1',
+  },
+  description: 'VAIT Homepage Certification Stack',
+});
+
+const homepageStack = new HomepageStack(app, 'HomepageStack', {
   env: {
     account: process.env.AWS_ACCOUNT_ID,
     region: 'ap-southeast-2',
   },
+  description: 'VAIT Homepage Stack',
 });
+homepageStack.addDependency(certStack);

--- a/infra/lib/cert-stack.ts
+++ b/infra/lib/cert-stack.ts
@@ -1,0 +1,21 @@
+import * as cdk from 'aws-cdk-lib';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import type { Construct } from 'constructs';
+
+import { BASE_DOMAIN } from './constants';
+
+export class CertStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const hostedZone = route53.HostedZone.fromLookup(this, 'VAITHostedZone', { domainName: BASE_DOMAIN });
+    const siteDomain = `home.${BASE_DOMAIN}`;
+
+    const certificate = new acm.Certificate(this, 'SiteCertificate', {
+      domainName: siteDomain,
+      validation: acm.CertificateValidation.fromDns(hostedZone),
+    });
+    new cdk.CfnOutput(this, 'Certificate', { value: certificate.certificateArn });
+  }
+}

--- a/infra/lib/constants.ts
+++ b/infra/lib/constants.ts
@@ -1,0 +1,2 @@
+export const BASE_DOMAIN = 'vietausit.com';
+export const SITE_DOMAIN = 'home.vietausit.com';


### PR DESCRIPTION
## Context

This is because for global entities (like CloudFront), the certificate needs to live in US-East-1. Our previous deployments run into an error here:
https://github.com/viet-aus-it/homepage/actions/runs/15338371684/job/43159777991

`HomepageSiteDistribution (HomepageSiteDistribution0FC4FC78) Resource handler returned message: "Invalid request provided: The specified SSL certificate doesn't exist, isn't in us-east-1 region, isn't valid, or doesn't include a valid certificate chain. (Service: CloudFront, Status Code: 400, Request ID: d4d0ccaa-88ed-43ae-9607-f67596424c45) (SDK Attempt Count: 1)"`

## Changes

- Create a seperate `CertStack` to create a cert in ACM in US-East 1 region

## Caveat

- `acm.DnsValidatedCertificate` is a deprecated construct, and dealing with proper cross stack regional reference in AWS is still experimental and plainly a PITA (see https://github.com/aws/aws-cdk/issues/30119 and https://github.com/aws/aws-cdk/issues/27902). I'll revise this construct when they come up with a new solution.

## Checklist

- [x] Code builds and runs locally
- [x] Lint and formatting checks pass
- [x] Tests pass (if applicable)
- [x] Documentation updated (if needed)
