### PR TITLE
Enable caching for cloudfront distribution to reduce on on s3 request

### DIFF
--- a/infra/lib/homepage-stack.ts
+++ b/infra/lib/homepage-stack.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import * as cdk from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as cloudfront_origins from 'aws-cdk-lib/aws-cloudfront-origins';
@@ -46,6 +47,17 @@ export class HomepageStack extends cdk.Stack {
         compress: true,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: new cloudfront.CachePolicy(this, 'LongTimeCachingPolicy', {
+          cachePolicyName: 'LongTimeCachingPolicy',
+          defaultTtl: Duration.hours(24),
+          maxTtl: Duration.days(365),
+          minTtl: Duration.seconds(0),
+          cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+          headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+          queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
+          enableAcceptEncodingGzip: true,
+          enableAcceptEncodingBrotli: true,
+        }),
       },
       errorResponses: [
         {


### PR DESCRIPTION
## Context
We should enable cf caching instead of serving directly from S3, cf bills per request and that including the request that hit the cf cache

## Changes
- Enable cache config for cloudfront distribution with a TTL of 1 day


## Checklist
<!-- Checklist of what was tested or completed. Add/remove as needed. -->

- [ ] Code builds and runs locally
- [x] Lint and formatting checks pass
- [ ] Tests pass (if applicable)
- [ ] Documentation updated (if needed)
