### PR TITLE
feat(infra): revert update cert to use the root ACM

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 
+import { CertStack } from '../lib/cert-stack';
 import { HomepageStack } from '../lib/homepage-stack';
 
 const app = new cdk.App();
@@ -9,10 +10,19 @@ const tags = cdk.Tags.of(app);
 tags.add('app', 'Homepage');
 tags.add('repo', 'https://github.com/viet-aus-it/homepage');
 
-new HomepageStack(app, 'HomepageStack', {
+const certStack = new CertStack(app, 'HomepageCertStack', {
+  env: {
+    account: process.env.AWS_ACCOUNT_ID,
+    region: 'us-east-1',
+  },
+  description: 'VAIT Homepage Certification Stack',
+});
+
+const homepageStack = new HomepageStack(app, 'HomepageStack', {
   env: {
     account: process.env.AWS_ACCOUNT_ID,
     region: 'ap-southeast-2',
   },
   description: 'VAIT Homepage Stack',
 });
+homepageStack.addDependency(certStack);

--- a/infra/lib/cert-stack.ts
+++ b/infra/lib/cert-stack.ts
@@ -1,0 +1,21 @@
+import * as cdk from 'aws-cdk-lib';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import type { Construct } from 'constructs';
+
+import { BASE_DOMAIN } from './constants';
+
+export class CertStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const hostedZone = route53.HostedZone.fromLookup(this, 'VAITHostedZone', { domainName: BASE_DOMAIN });
+    const siteDomain = `home.${BASE_DOMAIN}`;
+
+    const certificate = new acm.Certificate(this, 'SiteCertificate', {
+      domainName: siteDomain,
+      validation: acm.CertificateValidation.fromDns(hostedZone),
+    });
+    new cdk.CfnOutput(this, 'Certificate', { value: certificate.certificateArn });
+  }
+}

--- a/infra/lib/constants.ts
+++ b/infra/lib/constants.ts
@@ -1,3 +1,2 @@
 export const BASE_DOMAIN = 'vietausit.com';
 export const SITE_DOMAIN = 'home.vietausit.com';
-export const WWW_DOMAIN = 'www.vietausit.com';

--- a/infra/lib/homepage-stack.ts
+++ b/infra/lib/homepage-stack.ts
@@ -9,7 +9,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3_deployment from 'aws-cdk-lib/aws-s3-deployment';
 import type { Construct } from 'constructs';
 
-import { BASE_DOMAIN, SITE_DOMAIN, WWW_DOMAIN } from './constants';
+import { BASE_DOMAIN, SITE_DOMAIN } from './constants';
 
 export class HomepageStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -23,7 +23,7 @@ export class HomepageStack extends cdk.Stack {
      */
     const certificate = new acm.DnsValidatedCertificate(this, 'VAITHomeCertificate', {
       region: 'us-east-1',
-      domainName: `*.${BASE_DOMAIN}`,
+      domainName: SITE_DOMAIN,
       hostedZone: zone,
     });
 
@@ -39,7 +39,7 @@ export class HomepageStack extends cdk.Stack {
     const distribution = new cloudfront.Distribution(this, 'HomepageSiteDistribution', {
       defaultRootObject: 'index.html',
       certificate,
-      domainNames: [SITE_DOMAIN, BASE_DOMAIN, WWW_DOMAIN],
+      domainNames: [SITE_DOMAIN],
       minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
       defaultBehavior: {
         origin: cloudfront_origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
@@ -65,18 +65,8 @@ export class HomepageStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
 
     const siteDomainTarget = new route53_targets.CloudFrontTarget(distribution);
-    new route53.ARecord(this, 'HomepageAliasRecord', {
+    new route53.ARecord(this, 'SiteAliasRecord', {
       recordName: SITE_DOMAIN,
-      target: route53.RecordTarget.fromAlias(siteDomainTarget),
-      zone,
-    });
-    new route53.ARecord(this, 'BaseAliasRecord', {
-      recordName: BASE_DOMAIN,
-      target: route53.RecordTarget.fromAlias(siteDomainTarget),
-      zone,
-    });
-    new route53.ARecord(this, 'WwwAliasRecord', {
-      recordName: WWW_DOMAIN,
       target: route53.RecordTarget.fromAlias(siteDomainTarget),
       zone,
     });


### PR DESCRIPTION
## Context

PR #13 was causing deployment errors, so i'm reverting to unblock other PRs from deploying.



## Changes

- Put back the cert stack
- Revert attaching the base and www domain into cloudfront


## Checklist
<!-- Checklist of what was tested or completed. Add/remove as needed. -->

- [x] Code builds and runs locally
- [x] Lint and formatting checks pass
- [ ] Tests pass (if applicable)
- [ ] Documentation updated (if needed)
