### PR TITLE
feat(infra): register cert for home and www domain

### DIFF
--- a/infra/cdk.context.json
+++ b/infra/cdk.context.json
@@ -1,0 +1,10 @@
+{
+  "hosted-zone:account=415927671471:domainName=vietausit.com:region=us-east-1": {
+    "Id": "/hostedzone/Z077369421PGT0PNQ9P1N",
+    "Name": "vietausit.com."
+  },
+  "hosted-zone:account=415927671471:domainName=vietausit.com:region=ap-southeast-2": {
+    "Id": "/hostedzone/Z077369421PGT0PNQ9P1N",
+    "Name": "vietausit.com."
+  }
+}

--- a/infra/lib/cert-stack.ts
+++ b/infra/lib/cert-stack.ts
@@ -3,17 +3,17 @@ import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import type { Construct } from 'constructs';
 
-import { BASE_DOMAIN } from './constants';
+import { BASE_DOMAIN, SITE_DOMAIN, WWW_DOMAIN } from './constants';
 
 export class CertStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const hostedZone = route53.HostedZone.fromLookup(this, 'VAITHostedZone', { domainName: BASE_DOMAIN });
-    const siteDomain = `home.${BASE_DOMAIN}`;
 
     const certificate = new acm.Certificate(this, 'SiteCertificate', {
-      domainName: siteDomain,
+      domainName: BASE_DOMAIN,
+      subjectAlternativeNames: [SITE_DOMAIN, WWW_DOMAIN],
       validation: acm.CertificateValidation.fromDns(hostedZone),
     });
     new cdk.CfnOutput(this, 'Certificate', { value: certificate.certificateArn });

--- a/infra/lib/constants.ts
+++ b/infra/lib/constants.ts
@@ -1,2 +1,3 @@
 export const BASE_DOMAIN = 'vietausit.com';
-export const SITE_DOMAIN = 'home.vietausit.com';
+export const SITE_DOMAIN = `home.${BASE_DOMAIN}`;
+export const WWW_DOMAIN = `www.${BASE_DOMAIN}`;


### PR DESCRIPTION
## Context

Continuing the work from PR #13 & #16, this is another attempt to register a cert for the home page site, while attaching the base and www domain to it as well.


## Changes
<!-- What are the key changes in this PR? Bullet points preferred. -->

- feat(infra): register cert for home and www domain
- feat(infra): attach domains into cloudfront distribution


## Checklist
<!-- Checklist of what was tested or completed. Add/remove as needed. -->

- [x] Code builds and runs locally
- [x] Lint and formatting checks pass
- [x] Tests pass (if applicable)
- [x] Documentation updated (if needed)
