### PR TITLE
doc: draft DESIGN.md for VAIT homepage

### DIFF
--- a/.agents/rules/code-style.md
+++ b/.agents/rules/code-style.md
@@ -8,6 +8,7 @@ This document provides comprehensive code style guidelines for the VAIT Homepage
 - **Readability first**: Code should be self-documenting where possible
 - **Type safety**: Leverage TypeScript to catch errors at compile time
 - **Performance awareness**: Write code that renders efficiently
+- **Visual design**: Marketing UI must follow [DESIGN.md](../../DESIGN.md); use `--brand-*` tokens from `src/index.css`, not ad hoc hex in components
 
 ## TypeScript Configuration
 

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -19,6 +19,7 @@ When user asks to:
 | Location | Content | Key Sections |
 |----------|---------|-------------|
 | `README.md` | Project overview, setup, tech stack | Overview, quick start, commands |
+| `DESIGN.md` | Homepage visual design system | Colours, typography, components, do's/don'ts |
 | `docs/` | User-facing docs ([Diataxis](https://diataxis.fr/) framework) | Tutorials, how-to guides, explanation, reference |
 | `AGENTS.md` | Agent control manifest | Project structure, tech stack, available skills/rules, commands |
 | `.agents/rules/` | Domain-specific guidelines | Code style, patterns, commands, engineering principles, communication, special considerations, infrastructure |
@@ -59,6 +60,7 @@ For each category, note which documentation locations are affected using the map
 | Change Type | Docs to Check |
 |-------------|---------------|
 | New feature/component | `README.md`, `docs/explanation/01-architecture.md`, `AGENTS.md` (project structure) |
+| Marketing UI / brand / layout | `DESIGN.md`, `docs/index.md`, `docs/explanation/01-architecture.md`, `docs/how-to/01-development.md`, `docs/how-to/02-contributing.md`, `AGENTS.md` |
 | New dependency | `README.md`, `AGENTS.md` (tech stack), `docs/reference/01-project-reference.md` |
 | New command/script | `README.md`, `AGENTS.md` (commands), `docs/reference/01-project-reference.md`, `.agents/rules/commands.md` |
 | Infrastructure change | `docs/explanation/02-infrastructure.md`, `docs/how-to/03-deployment.md`, `.agents/rules/infrastructure.md` |
@@ -114,6 +116,7 @@ pnpm run lint
 - [ ] Commit range identified and all changes reviewed
 - [ ] Changes categorised by documentation impact
 - [ ] `README.md` checked and updated
+- [ ] `DESIGN.md` checked when UI tokens, components, or layout change
 - [ ] `docs/` files checked and updated for affected topics
 - [ ] `AGENTS.md` checked: project structure, tech stack, skills, rules, commands
 - [ ] `.agents/rules/` checked for affected rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ You are working on the VAIT Homepage, the official website for the Viet-Aus IT c
 - **Team**: VAIT (Vietnamese Australians in Information Technology community)
 - **Tech Stack**: [React](https://react.dev/) 19, [Vite](https://vite.dev/), [TypeScript](https://www.typescriptlang.org/), [TanStack Router](https://tanstack.com/router), [Zod](https://zod.dev/), [Biome](https://biomejs.dev/), [Vitest](https://vitest.dev/)
 - **Architecture**: Component-based architecture with type-safe routing and state management
+- **Visual design**: [DESIGN.md](DESIGN.md) — tokens, components, and do's/don'ts for the public homepage (warm canvas, brand yellow, shadcn/Tailwind)
 - **Infrastructure**: [AWS CDK](https://docs.aws.amazon.com/cdk/), [S3](https://aws.amazon.com/s3/), [CloudFront](https://aws.amazon.com/cloudfront/) for deployment
 
 ## Change Management Philosophy
@@ -47,6 +48,7 @@ All changes must be:
     communication.md
     special-considerations.md
     infrastructure.md
+DESIGN.md                # Visual design system (homepage UI — read before marketing UI changes)
 docs/
   index.md               # Documentation hub (Diataxis framework)
   tutorials/             # Learning-oriented guides
@@ -58,15 +60,16 @@ docs/
 ## Execution Protocol
 
 1. **Always read this file first** before starting a task so you know which skills or rules to load from `.agents/`.
-2. **Skills**:
+2. **Visual / marketing UI** (colours, typography, layout, new homepage sections, brand components): read [DESIGN.md](DESIGN.md) before editing `src/components/` or `src/pages/`. Update `DESIGN.md` in the same pull request when you add or change design tokens, named components, or documented behaviour.
+3. **Skills**:
    - Load a skill only if its trigger condition matches the task. Example: code review tasks must load `skills/code-review/SKILL.md`.
    - Once loaded, obey the process and output format defined inside the skill file so the final response stays consistent.
    - Skills are located in `.agents/skills/[skill-name]/SKILL.md`
-3. **Rules**:
+4. **Rules**:
    - Rules are long-lived constraints (API guidelines, coding practices, etc.). Whenever a task touches those domains, read the matching file under `.agents/rules/`.
    - Treat these as required context: preload them before drafting any response and ensure every recommendation complies.
    - Rules are located in `.agents/rules/[rule-name].md`
-4. **Response contract**:
+5. **Response contract**:
    - Explicitly mention which skills and rules are in effect.
    - Derive findings, recommendations, or code while enforcing all loaded constraints. If conflicts arise, ask for clarification before diverging.
 
@@ -81,6 +84,10 @@ Load these rules when working on relevant domains:
 - **[communication.md](.agents/rules/communication.md)** - Communication style and output expectations
 - **[special-considerations.md](.agents/rules/special-considerations.md)** - Browser compatibility, SEO, accessibility, deployment
 - **[infrastructure.md](.agents/rules/infrastructure.md)** - AWS CDK patterns, deployment strategies, and operational best practices
+
+## Visual Design System
+
+- **[DESIGN.md](DESIGN.md)** — Canonical reference for the public homepage: colour tokens (`{colors.*}`), typography scale, layout, elevation, component keys (`{component.*}`), responsive behaviour, iteration guide, and known gaps. Pair with **[code-style.md](.agents/rules/code-style.md)** and **[special-considerations.md](.agents/rules/special-considerations.md)** for accessibility and implementation detail.
 
 ## Available Skills
 
@@ -115,6 +122,7 @@ pnpm run typecheck    # Run TypeScript type checking
 - **Type safety**: Strict TypeScript with no `any`
 - **Performance first**: [Core Web Vitals](https://web.dev/articles/vitals) optimisation
 - **Accessibility**: [WCAG 2.1](https://www.w3.org/WAI/WCAG21/quickref/) AA compliance
+- **Visual consistency**: Follow [DESIGN.md](DESIGN.md) for marketing UI; keep tokens in `src/index.css` (`--brand-*`)
 
 ## Rules vs. Skills at a Glance
 
@@ -132,4 +140,4 @@ Think of **rules** as a "manual" that keeps behavior aligned, while **skills** a
 - Additional **skills** (architecture review, test planning, etc.) or **rules** (team code style, compliance requirements) can be added under the existing folders.
 - Keep this file updated so future agents know when to load each artifact and how to combine them safely.
 
-Remember: You're supporting the VAIT community homepage. Focus on clean, performant, and accessible code that serves the community well. When in doubt, follow existing patterns in the codebase and refer to the relevant rules.
+Remember: You're supporting the VAIT community homepage. Focus on clean, performant, and accessible code that serves the community well. When in doubt, follow existing patterns in the codebase, [DESIGN.md](DESIGN.md) for visual work, and the relevant rules.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,6 +7,7 @@ Type voice runs the **system UI stack** (shadcn/Tailwind default sans) at **semi
 Component voltage comes from three anchors: the **floating pill nav** (`{component.nav-bar}`), the **full-viewport hero** with community CTA, and a **white elevated content shell** (`{component.content-shell}`) that holds alternating image/text bands. The **dark charcoal footer** (`{component.footer}`) inverts the warm page — yellow legal text on gray-dark — so the site closes with institutional weight, not another cream band.
 
 **Key Characteristics:**
+
 - Warm stone canvas (`{colors.canvas}`) plus cream gradient backdrop (`{colors.backdrop-from}` — `#fffbea` → white → `#fef9ef`).
 - Brand yellow accent (`{colors.brand-yellow}` — `#f4df4d`) on CTAs, footer ink, and section titles; gray scale for structure (`{colors.brand-gray}`, `{colors.brand-gray-dark}`).
 - Tick-and-star **VAIT logo** SVG (`{component.logo}`) with three colourways: full colour, gray, dark-gray.
@@ -18,6 +19,7 @@ Component voltage comes from three anchors: the **floating pill nav** (`{compone
 ## Colors
 
 ### Brand & Accent
+
 - **Brand Yellow** (`{colors.brand-yellow}` — `#f4df4d`): Primary CTA fill, footer headline text, logo primary ticks. Logo source also lists `#F5DF4D` — treat as the same family; CSS token is canonical for the site.
 - **Brand Yellow Dark** (`{colors.brand-yellow-dark}` — `#e0c944`): Section h2 emphasis (`text-brand-yellow-dark`).
 - **Brand Yellow Darker** (`{colors.brand-yellow-darker}` — `#c7b139`): Deeper yellow for future badges or hover depth (utility classes exist; lightly used today).
@@ -25,6 +27,7 @@ Component voltage comes from three anchors: the **floating pill nav** (`{compone
 - **Brand Gray Dark** (`{colors.brand-gray-dark}` — `#1c1c1c`): Footer background, CTA label ink, hero subtitle (`text-brand-dark-gray` in components — maps to this token).
 
 ### Surface
+
 - **Canvas** (`{colors.canvas}` — `stone-50` / ~`#fafaf9`): Page floor on `{page.index}`.
 - **Backdrop From** (`{colors.backdrop-from}` — `#fffbea`): Gradient start on `{component.futuristic-background}`.
 - **Backdrop Via** (`{colors.backdrop-via}` — `#ffffff`): Gradient centre.
@@ -36,6 +39,7 @@ Component voltage comes from three anchors: the **floating pill nav** (`{compone
 - **Hairline** (`{colors.hairline}` — `{colors.border}` / oklch border token): Nav border, shadcn inputs.
 
 ### Text
+
 - **Ink** (`{colors.ink}` — `{colors.foreground}`): Default body from shadcn theme (~near-black oklch).
 - **Body** (`{colors.body}` — `gray-700`): Section descriptions in `{component.section-with-image}`.
 - **Muted** (`{colors.muted}` — `{colors.muted-foreground}`): shadcn muted copy where used.
@@ -43,6 +47,7 @@ Component voltage comes from three anchors: the **floating pill nav** (`{compone
 - **On Dark** (`{colors.on-dark}` — `{colors.brand-yellow}`): Footer primary line on charcoal.
 
 ### Semantic (shadcn)
+
 - **Primary** (`{colors.primary}`): shadcn default button (outline nav icon uses `{component.button-outline}`).
 - **Destructive** (`{colors.destructive}`): Form/error states (reserved).
 - **Ring** (`{colors.ring}`): Focus rings on interactive elements.
@@ -50,32 +55,36 @@ Component voltage comes from three anchors: the **floating pill nav** (`{compone
 ## Typography
 
 ### Font Family
+
 The system uses the **Tailwind/shadcn default sans stack** (system UI). No custom webfont is loaded in `index.html`. Headlines rely on **weight and size**, not a display face.
 
 ### Hierarchy
 
-| Token | Size | Weight | Line Height | Letter Spacing | Use |
-|---|---|---|---|---|---|
-| `{typography.display-hero}` | 36–60px (`text-4xl` → `text-6xl`) | 600 | 1.2 | tight | Hero h1 |
-| `{typography.display-subhero}` | 30–36px (`text-3xl` → `text-4xl`) | 400 (default) | default | tight | Hero h2 / subtitle |
-| `{typography.title-section}` | 24–30px (`text-2xl` → `text-3xl`) | 600 | default | 0 | Section h2 — brand yellow-dark |
-| `{typography.body}` | 16px (default) | 400 | default | 0 | Section descriptions (`text-gray-700`) |
-| `{typography.footer}` | 14px (`text-sm`) | 400 | default | 0 | Footer legal lines |
-| `{typography.button-cta}` | 18px (`text-lg`) | 600 | default | 0 | Join Community CTA |
-| `{typography.nav-link}` | 14px (`text-sm`) | 500 | default | 0 | Desktop nav items (shadcn NavigationMenu) |
-| `{typography.badge}` | 12px (`text-xs`) | 500 | default | 0 | Section anchor badges (`#{sectionId}`) |
+| Token                          | Size                              | Weight        | Line Height | Letter Spacing | Use                                       |
+| ------------------------------ | --------------------------------- | ------------- | ----------- | -------------- | ----------------------------------------- |
+| `{typography.display-hero}`    | 36–60px (`text-4xl` → `text-6xl`) | 600           | 1.2         | tight          | Hero h1                                   |
+| `{typography.display-subhero}` | 30–36px (`text-3xl` → `text-4xl`) | 400 (default) | default     | tight          | Hero h2 / subtitle                        |
+| `{typography.title-section}`   | 24–30px (`text-2xl` → `text-3xl`) | 600           | default     | 0              | Section h2 — brand yellow-dark            |
+| `{typography.body}`            | 16px (default)                    | 400           | default     | 0              | Section descriptions (`text-gray-700`)    |
+| `{typography.footer}`          | 14px (`text-sm`)                  | 400           | default     | 0              | Footer legal lines                        |
+| `{typography.button-cta}`      | 18px (`text-lg`)                  | 600           | default     | 0              | Join Community CTA                        |
+| `{typography.nav-link}`        | 14px (`text-sm`)                  | 500           | default     | 0              | Desktop nav items (shadcn NavigationMenu) |
+| `{typography.badge}`           | 12px (`text-xs`)                  | 500           | default     | 0              | Section anchor badges (`#{sectionId}`)    |
 
 ### Principles
+
 - **One accent colour in type**: yellow-dark for section titles; avoid introducing a second headline colour without updating tokens.
 - **Hero subtitle** uses charcoal (`{colors.brand-gray-dark}`), not muted gray — keeps the value prop readable on warm backgrounds.
 - **Semibold** is the ceiling for marketing headlines; heavier weights are unnecessary on the system stack.
 
 ### Note on Font Substitutes
+
 When a display face is introduced, prefer a **warm, slightly rounded sans** (e.g. DM Sans, Plus Jakarta Sans) that harmonises with yellow without competing with the logo ticks. Until then, tighten tracking on display sizes only.
 
 ## Layout
 
 ### Spacing System
+
 - **Base unit:** 4px (Tailwind default).
 - **Tokens:** `{spacing.1}` 4px · `{spacing.2}` 8px · `{spacing.3}` 12px · `{spacing.4}` 16px · `{spacing.6}` 24px · `{spacing.8}` 32px · `{spacing.16}` 64px.
 - **Nav offset:** `top-6` + `inset-x-4` — floating nav breathes below viewport edge.
@@ -83,27 +92,30 @@ When a display face is introduced, prefer a **warm, slightly rounded sans** (e.g
 - **Hero:** `min-h-screen`, centred column, `max-w-screen-md` for copy.
 
 ### Grid & Container
+
 - **Max content width:** `max-w-screen-lg` (~1024px) for nav, content shell, and section grid.
 - **Hero:** Single centred column; background is full-bleed fixed layer.
 - **Sections:** `grid-cols-1` → `md:grid-cols-2` with `md:gap-16`; `reverse` alternates image/text order.
 - **Footer:** Full-width band, centred stacked legal copy.
 
 ### Whitespace Philosophy
+
 VAIT uses **vertical rhythm through full-viewport hero + card shell** rather than many separated bands. Warm background fills negative space; the white shell concentrates scan path for three feature stories. Avoid adding more boxed cards inside the shell — alternation already provides rhythm.
 
 ## Elevation & Depth
 
-| Level | Treatment | Use |
-|---|---|---|
+| Level         | Treatment                                        | Use                                 |
+| ------------- | ------------------------------------------------ | ----------------------------------- |
 | Flat backdrop | Fixed gradient + soft blobs + noise line texture | `{component.futuristic-background}` |
-| Floating nav | `bg-background` + border, no heavy shadow | `{component.nav-bar}` |
-| Content shell | `shadow-md` on white card | `{component.content-shell}` |
-| CTA emphasis | `shadow-lg` on yellow pill | `{component.join-community-cta}` |
-| Footer band | Flat charcoal, top border `border-brand-gray` | `{component.footer}` |
+| Floating nav  | `bg-background` + border, no heavy shadow        | `{component.nav-bar}`               |
+| Content shell | `shadow-md` on white card                        | `{component.content-shell}`         |
+| CTA emphasis  | `shadow-lg` on yellow pill                       | `{component.join-community-cta}`    |
+| Footer band   | Flat charcoal, top border `border-brand-gray`    | `{component.footer}`                |
 
 Depth is **atmospheric** (gradient blobs) plus **one card elevation** for editorial content — not a multi-shadow marketing stack.
 
 ### Decorative Depth
+
 - **Animated warm blobs** — pulse animation, heavy blur; not tokenised beyond hex fills above.
 - **Repeating hairline texture** — 1px horizontal lines at 0.5% black alpha over the backdrop.
 
@@ -111,14 +123,14 @@ Depth is **atmospheric** (gradient blobs) plus **one card elevation** for editor
 
 ### Border Radius Scale
 
-| Token | Value | Use |
-|---|---|---|
-| `{rounded.sm}` | `calc(var(--radius) - 4px)` (~6px) | shadcn small controls |
-| `{rounded.md}` | `calc(var(--radius) - 2px)` (~8px) | Default buttons, badges |
-| `{rounded.lg}` | `var(--radius)` (10px / 0.625rem) | Base `--radius` in `:root` |
-| `{rounded.xl}` | `calc(var(--radius) + 4px)` (~14px) | shadcn xl variant |
-| `{rounded.2xl}` | 16px (Tailwind) | Content shell |
-| `{rounded.full}` | 9999px | Nav bar, Discord CTA, outline icon button |
+| Token            | Value                               | Use                                       |
+| ---------------- | ----------------------------------- | ----------------------------------------- |
+| `{rounded.sm}`   | `calc(var(--radius) - 4px)` (~6px)  | shadcn small controls                     |
+| `{rounded.md}`   | `calc(var(--radius) - 2px)` (~8px)  | Default buttons, badges                   |
+| `{rounded.lg}`   | `var(--radius)` (10px / 0.625rem)   | Base `--radius` in `:root`                |
+| `{rounded.xl}`   | `calc(var(--radius) + 4px)` (~14px) | shadcn xl variant                         |
+| `{rounded.2xl}`  | 16px (Tailwind)                     | Content shell                             |
+| `{rounded.full}` | 9999px                              | Nav bar, Discord CTA, outline icon button |
 
 ## Components
 
@@ -161,6 +173,7 @@ Depth is **atmospheric** (gradient blobs) plus **one card elevation** for editor
 ## Do's and Don'ts
 
 ### Do
+
 - Keep the page on **warm stone + cream gradient** — it signals community, not enterprise SaaS cold gray.
 - Use **brand yellow** only for emphasis: CTAs, footer highlights, section titles — not body paragraphs.
 - Keep **Discord** as the primary outward CTA unless a second channel is officially approved.
@@ -170,6 +183,7 @@ Depth is **atmospheric** (gradient blobs) plus **one card elevation** for editor
 - Honour `prefers-reduced-motion` when extending blob animations (not yet wired).
 
 ### Don't
+
 - Don't add a second competing accent (e.g. blue CTAs) without updating `{colors.brand-yellow}` contract.
 - Don't flatten the page to pure white — lose `{component.futuristic-background}` and the site reads generic.
 - Don't use the dark footer palette in the hero body — warmth is the opening move; charcoal is the close.
@@ -181,17 +195,19 @@ Depth is **atmospheric** (gradient blobs) plus **one card elevation** for editor
 
 ### Breakpoints
 
-| Name | Width | Key Changes |
-|---|---|---|
-| Mobile | < 768px | `{component.nav-sheet}` replaces `{component.nav-menu}`; hero type scales down (`text-4xl` h1); sections single column |
-| Tablet / Desktop | ≥ 768px | Full horizontal nav; section grids 2-column; footer legal inline with separator |
-| Wide | ≥ 1024px | `max-w-screen-lg` containers centred with side margin via `mx-auto` |
+| Name             | Width    | Key Changes                                                                                                            |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Mobile           | < 768px  | `{component.nav-sheet}` replaces `{component.nav-menu}`; hero type scales down (`text-4xl` h1); sections single column |
+| Tablet / Desktop | ≥ 768px  | Full horizontal nav; section grids 2-column; footer legal inline with separator                                        |
+| Wide             | ≥ 1024px | `max-w-screen-lg` containers centred with side margin via `mx-auto`                                                    |
 
 ### Touch Targets
+
 - `{component.join-community-cta}` — `size="lg"` shadcn button (~48px height target).
 - Nav Discord icon button — `size="icon"`; ensure 44×44px hit area when auditing.
 
 ### Collapsing Strategy
+
 - Nav collapses to sheet under `md`.
 - Hero remains centred single column at all breakpoints.
 - Section images stack below copy on mobile regardless of `reverse`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,218 @@
+## Overview
+
+The VAIT homepage is the public face of **Vietnamese Australians in Information Technology Inc.** — a not-for-profit community for Viet-Au IT professionals in Australia. The base atmosphere is a **warm cream-and-stone canvas** (`{colors.canvas}` — stone-50 / `#fafaf9`) with a **fixed animated gradient backdrop** (`{component.futuristic-background}`) and **charcoal ink** for reading. Where many community sites default to cold corporate blue, VAIT leads with **brand yellow** (`{colors.brand-yellow}` — `#f4df4d`) as the single high-voltage accent — echoed in the tick-and-star logo, section headings, footer type, and the primary Discord CTA.
+
+Type voice runs the **system UI stack** (shadcn/Tailwind default sans) at **semibold display weights** for hero and section titles, with **tracking-tight** on headlines. There is no licensed display face yet; hierarchy is carried by size steps (36px → 60px hero) and colour (yellow-dark for section h2, gray-700 for body).
+
+Component voltage comes from three anchors: the **floating pill nav** (`{component.nav-bar}`), the **full-viewport hero** with community CTA, and a **white elevated content shell** (`{component.content-shell}`) that holds alternating image/text bands. The **dark charcoal footer** (`{component.footer}`) inverts the warm page — yellow legal text on gray-dark — so the site closes with institutional weight, not another cream band.
+
+**Key Characteristics:**
+- Warm stone canvas (`{colors.canvas}`) plus cream gradient backdrop (`{colors.backdrop-from}` — `#fffbea` → white → `#fef9ef`).
+- Brand yellow accent (`{colors.brand-yellow}` — `#f4df4d`) on CTAs, footer ink, and section titles; gray scale for structure (`{colors.brand-gray}`, `{colors.brand-gray-dark}`).
+- Tick-and-star **VAIT logo** SVG (`{component.logo}`) with three colourways: full colour, gray, dark-gray.
+- **Discord** as the single primary conversion path (`{component.join-community-cta}`).
+- Generous pill radii: `{rounded.full}` for nav and CTA, `{rounded.2xl}` for the content shell, `{rounded.md}` for shadcn defaults.
+- Alternating **7/5-style** two-column sections (`{component.section-with-image}`) with real community photography.
+- Footer is **dark** (`{colors.brand-gray-dark}`) — deliberate contrast to the warm page body.
+
+## Colors
+
+### Brand & Accent
+- **Brand Yellow** (`{colors.brand-yellow}` — `#f4df4d`): Primary CTA fill, footer headline text, logo primary ticks. Logo source also lists `#F5DF4D` — treat as the same family; CSS token is canonical for the site.
+- **Brand Yellow Dark** (`{colors.brand-yellow-dark}` — `#e0c944`): Section h2 emphasis (`text-brand-yellow-dark`).
+- **Brand Yellow Darker** (`{colors.brand-yellow-darker}` — `#c7b139`): Deeper yellow for future badges or hover depth (utility classes exist; lightly used today).
+- **Brand Gray** (`{colors.brand-gray}` — `#959595`): Footer divider, secondary logo paths, CTA hover background. Logo secondary: `#939597`.
+- **Brand Gray Dark** (`{colors.brand-gray-dark}` — `#1c1c1c`): Footer background, CTA label ink, hero subtitle (`text-brand-dark-gray` in components — maps to this token).
+
+### Surface
+- **Canvas** (`{colors.canvas}` — `stone-50` / ~`#fafaf9`): Page floor on `{page.index}`.
+- **Backdrop From** (`{colors.backdrop-from}` — `#fffbea`): Gradient start on `{component.futuristic-background}`.
+- **Backdrop Via** (`{colors.backdrop-via}` — `#ffffff`): Gradient centre.
+- **Backdrop To** (`{colors.backdrop-to}` — `#fef9ef`): Gradient end.
+- **Blob Peach** (`{colors.blob-peach}` — `#ffe7d6`): Top-left animated blob (30% opacity, blur).
+- **Blob Cream** (`{colors.blob-cream}` — `#ffeacc`): Bottom-right animated blob.
+- **Surface Card** (`{colors.surface-card}` — `#ffffff`): Main content shell — white, `rounded-2xl`, `shadow-md`.
+- **Surface Nav** (`{colors.surface-nav}` — `{colors.background}` / shadcn `background`): Floating nav pill fill.
+- **Hairline** (`{colors.hairline}` — `{colors.border}` / oklch border token): Nav border, shadcn inputs.
+
+### Text
+- **Ink** (`{colors.ink}` — `{colors.foreground}`): Default body from shadcn theme (~near-black oklch).
+- **Body** (`{colors.body}` — `gray-700`): Section descriptions in `{component.section-with-image}`.
+- **Muted** (`{colors.muted}` — `{colors.muted-foreground}`): shadcn muted copy where used.
+- **On Yellow** (`{colors.on-yellow}` — `{colors.brand-gray-dark}`): CTA label on yellow button.
+- **On Dark** (`{colors.on-dark}` — `{colors.brand-yellow}`): Footer primary line on charcoal.
+
+### Semantic (shadcn)
+- **Primary** (`{colors.primary}`): shadcn default button (outline nav icon uses `{component.button-outline}`).
+- **Destructive** (`{colors.destructive}`): Form/error states (reserved).
+- **Ring** (`{colors.ring}`): Focus rings on interactive elements.
+
+## Typography
+
+### Font Family
+The system uses the **Tailwind/shadcn default sans stack** (system UI). No custom webfont is loaded in `index.html`. Headlines rely on **weight and size**, not a display face.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-hero}` | 36–60px (`text-4xl` → `text-6xl`) | 600 | 1.2 | tight | Hero h1 |
+| `{typography.display-subhero}` | 30–36px (`text-3xl` → `text-4xl`) | 400 (default) | default | tight | Hero h2 / subtitle |
+| `{typography.title-section}` | 24–30px (`text-2xl` → `text-3xl`) | 600 | default | 0 | Section h2 — brand yellow-dark |
+| `{typography.body}` | 16px (default) | 400 | default | 0 | Section descriptions (`text-gray-700`) |
+| `{typography.footer}` | 14px (`text-sm`) | 400 | default | 0 | Footer legal lines |
+| `{typography.button-cta}` | 18px (`text-lg`) | 600 | default | 0 | Join Community CTA |
+| `{typography.nav-link}` | 14px (`text-sm`) | 500 | default | 0 | Desktop nav items (shadcn NavigationMenu) |
+| `{typography.badge}` | 12px (`text-xs`) | 500 | default | 0 | Section anchor badges (`#{sectionId}`) |
+
+### Principles
+- **One accent colour in type**: yellow-dark for section titles; avoid introducing a second headline colour without updating tokens.
+- **Hero subtitle** uses charcoal (`{colors.brand-gray-dark}`), not muted gray — keeps the value prop readable on warm backgrounds.
+- **Semibold** is the ceiling for marketing headlines; heavier weights are unnecessary on the system stack.
+
+### Note on Font Substitutes
+When a display face is introduced, prefer a **warm, slightly rounded sans** (e.g. DM Sans, Plus Jakarta Sans) that harmonises with yellow without competing with the logo ticks. Until then, tighten tracking on display sizes only.
+
+## Layout
+
+### Spacing System
+- **Base unit:** 4px (Tailwind default).
+- **Tokens:** `{spacing.1}` 4px · `{spacing.2}` 8px · `{spacing.3}` 12px · `{spacing.4}` 16px · `{spacing.6}` 24px · `{spacing.8}` 32px · `{spacing.16}` 64px.
+- **Nav offset:** `top-6` + `inset-x-4` — floating nav breathes below viewport edge.
+- **Section padding:** `py-8` inside sections; `my-8` around content shell; `my-16` around standalone CTA block.
+- **Hero:** `min-h-screen`, centred column, `max-w-screen-md` for copy.
+
+### Grid & Container
+- **Max content width:** `max-w-screen-lg` (~1024px) for nav, content shell, and section grid.
+- **Hero:** Single centred column; background is full-bleed fixed layer.
+- **Sections:** `grid-cols-1` → `md:grid-cols-2` with `md:gap-16`; `reverse` alternates image/text order.
+- **Footer:** Full-width band, centred stacked legal copy.
+
+### Whitespace Philosophy
+VAIT uses **vertical rhythm through full-viewport hero + card shell** rather than many separated bands. Warm background fills negative space; the white shell concentrates scan path for three feature stories. Avoid adding more boxed cards inside the shell — alternation already provides rhythm.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| Flat backdrop | Fixed gradient + soft blobs + noise line texture | `{component.futuristic-background}` |
+| Floating nav | `bg-background` + border, no heavy shadow | `{component.nav-bar}` |
+| Content shell | `shadow-md` on white card | `{component.content-shell}` |
+| CTA emphasis | `shadow-lg` on yellow pill | `{component.join-community-cta}` |
+| Footer band | Flat charcoal, top border `border-brand-gray` | `{component.footer}` |
+
+Depth is **atmospheric** (gradient blobs) plus **one card elevation** for editorial content — not a multi-shadow marketing stack.
+
+### Decorative Depth
+- **Animated warm blobs** — pulse animation, heavy blur; not tokenised beyond hex fills above.
+- **Repeating hairline texture** — 1px horizontal lines at 0.5% black alpha over the backdrop.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.sm}` | `calc(var(--radius) - 4px)` (~6px) | shadcn small controls |
+| `{rounded.md}` | `calc(var(--radius) - 2px)` (~8px) | Default buttons, badges |
+| `{rounded.lg}` | `var(--radius)` (10px / 0.625rem) | Base `--radius` in `:root` |
+| `{rounded.xl}` | `calc(var(--radius) + 4px)` (~14px) | shadcn xl variant |
+| `{rounded.2xl}` | 16px (Tailwind) | Content shell |
+| `{rounded.full}` | 9999px | Nav bar, Discord CTA, outline icon button |
+
+## Components
+
+### Top Navigation
+
+**`nav-bar`** — Fixed pill nav, 56px tall (`h-14`), `{colors.surface-nav}` background, `{rounded.full}`, `max-w-screen-lg` centred, `top-6` inset. Left: `{component.logo}` dark-gray. Centre/right: `{component.nav-menu}` (desktop) + vertical separator + Discord `{component.button-outline-icon}` + `{component.nav-sheet}` (mobile).
+
+**`nav-menu`** — Anchor links to `#knowledge-sharing`, `#networking-events`, `#professional-growth`. Hidden below `md`.
+
+**`nav-sheet`** — Mobile slide-out; carries logo + same anchors + Discord CTA pattern.
+
+### Buttons
+
+**`button-primary`** (shadcn default) — `{colors.primary}` fill; used sparingly on marketing surface.
+
+**`button-outline`** — Hairline border; Discord icon affordance in nav (`rounded-full`, `size="icon"`).
+
+**`join-community-cta`** — `{colors.brand-yellow}` background, `{colors.on-yellow}` text, `{rounded.full}`, `text-lg`, `shadow-lg`, Discord icon inline. Hover: `{colors.brand-gray}` background, white text. Links to `{links.discord}`.
+
+### Cards & Containers
+
+**`futuristic-background`** — `fixed inset-0 z-0` gradient layer with two pulsing blobs and subtle line texture. Sits behind all page content.
+
+**`hero`** — `min-h-screen` centred band; h1 `{typography.display-hero}`, h2 `{typography.display-subhero}`, embeds `{component.join-community-cta}`.
+
+**`content-shell`** — `bg-white rounded-2xl shadow-md p-8 my-8 max-w-screen-lg` wrapping all `{component.section-with-image}` blocks.
+
+**`section-with-image`** — Two-column section; `{component.badge}` with `#{sectionId}`; h2 in brand yellow-dark; body `{colors.body}`; image `rounded` (default lg radius). `reverse` flips column order at `md+`.
+
+**`footer`** — Full-width `{colors.brand-gray-dark}` band; `{colors.on-dark}` for ABN / Association lines; `{colors.brand-gray}` for copyright subline; centred stack, `md` row for legal pair.
+
+### Logo
+
+**`logo`** — SVG tick-and-star mark. Variants: `colour` (yellow + gray ticks), `gray`, `dark-gray` (charcoal + gray). Props: standard SVG attributes (`className`, `width`, `height`).
+
+### Tabs / Badges
+
+**`badge`** (shadcn secondary) — Section labels like `#knowledge-sharing`; small, muted fill.
+
+## Do's and Don'ts
+
+### Do
+- Keep the page on **warm stone + cream gradient** — it signals community, not enterprise SaaS cold gray.
+- Use **brand yellow** only for emphasis: CTAs, footer highlights, section titles — not body paragraphs.
+- Keep **Discord** as the primary outward CTA unless a second channel is officially approved.
+- Alternate `{component.section-with-image}` with `reverse` for scan rhythm.
+- Use the **dark footer** for legal/trust content — contrast anchors the organisation as established NFP.
+- Respect `max-w-screen-lg` for nav and editorial width — do not stretch text edge-to-edge on desktop.
+- Honour `prefers-reduced-motion` when extending blob animations (not yet wired).
+
+### Don't
+- Don't add a second competing accent (e.g. blue CTAs) without updating `{colors.brand-yellow}` contract.
+- Don't flatten the page to pure white — lose `{component.futuristic-background}` and the site reads generic.
+- Don't use the dark footer palette in the hero body — warmth is the opening move; charcoal is the close.
+- Don't introduce heavy card grids inside `{component.content-shell}` — one shell is enough elevation.
+- Don't document or rely on hover as a brand signal beyond existing CTA/nav patterns.
+- Don't load a cold geometric sans that fights the yellow warmth without a design review.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 768px | `{component.nav-sheet}` replaces `{component.nav-menu}`; hero type scales down (`text-4xl` h1); sections single column |
+| Tablet / Desktop | ≥ 768px | Full horizontal nav; section grids 2-column; footer legal inline with separator |
+| Wide | ≥ 1024px | `max-w-screen-lg` containers centred with side margin via `mx-auto` |
+
+### Touch Targets
+- `{component.join-community-cta}` — `size="lg"` shadcn button (~48px height target).
+- Nav Discord icon button — `size="icon"`; ensure 44×44px hit area when auditing.
+
+### Collapsing Strategy
+- Nav collapses to sheet under `md`.
+- Hero remains centred single column at all breakpoints.
+- Section images stack below copy on mobile regardless of `reverse`.
+- Content shell retains white card and horizontal padding (`px-4` page, `p-8` shell).
+
+## Iteration Guide
+
+1. Focus on **one component** per change — reference keys above (`{component.nav-bar}`, etc.).
+2. Map new colours to CSS variables in `src/index.css` (`--brand-*`) and add utilities in `@layer utilities` — avoid inline hex in components.
+3. When adding pages, reuse `{component.futuristic-background}` + `{component.nav-bar}` + footer pattern before inventing new shells.
+4. Section copy changes belong in page config (`sections` array on index) — not hard-coded in presentational components.
+5. Logo colour changes must update `LOGO_COLOURS` in `{component.logo}` and CSS tokens together.
+6. Display typography changes should update the hierarchy table in this file in the same PR.
+
+## Known Gaps
+
+- No custom webfont or formal `{typography.*}` CSS variables — sizes live in Tailwind classes only.
+- `text-brand-dark-gray` is used in components but the utility is named `text-brand-gray-dark` — align naming in a follow-up.
+- `{colors.brand-yellow}` vs logo `#F5DF4D` are slightly different hex values; consolidate to one token.
+- Dark mode tokens exist in `:root` / `.dark` but the marketing page does not toggle dark theme.
+- Blob animation timings and `prefers-reduced-motion` overrides are not formalised.
+- Form inputs and validation states are shadcn defaults — not extracted for marketing.
+- Additional routes (`not-found`, future pages) are not fully specified in this document.
+- In-app or member portal UI is out of scope — this file covers the public homepage only.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See [docs/index.md](docs/index.md) for more details.
 - [Biome](https://biomejs.dev/) for linting/formatting
 - [Husky](https://typicode.github.io/husky/) for git hooks
 - See [docs/how-to/01-development.md](docs/how-to/01-development.md) for workflow, conventions, and tips
+- Homepage visual design: [DESIGN.md](DESIGN.md) (colours, components, UI guidelines)
 
 ## Infrastructure
 - [AWS CDK](https://docs.aws.amazon.com/cdk/) (TypeScript)

--- a/docs/explanation/01-architecture.md
+++ b/docs/explanation/01-architecture.md
@@ -26,6 +26,7 @@ public/        — Static assets
 .github/       — CI/CD workflows (GitHub Actions)
 docs/          — Project documentation (Diataxis framework)
 .agents/       — AI agent rules and skills
+DESIGN.md      — Homepage visual design system (repository root)
 ```
 
 ## Design Principles
@@ -35,8 +36,20 @@ docs/          — Project documentation (Diataxis framework)
 - **Accessibility**: Targets [WCAG 2.1](https://www.w3.org/WAI/WCAG21/quickref/) AA compliance with semantic HTML and keyboard navigation
 - **Simplicity**: Minimal dependencies, clear code paths, no over-engineering
 
+## Visual Design
+
+Marketing UI is documented in [DESIGN.md](../../DESIGN.md) at the repository root (not under `docs/`). That file is the source of truth for:
+
+- Brand colours (`--brand-*` in `src/index.css`) and warm canvas/backdrop treatment
+- Named homepage components (`nav-bar`, `hero`, `content-shell`, `join-community-cta`, etc.)
+- Typography hierarchy, spacing, and responsive breakpoints
+- Do's and don'ts (e.g. brand yellow for emphasis only, dark footer, Discord as primary CTA)
+
+When changing landing-page visuals, read `DESIGN.md` first and update it in the same pull request if tokens or component contracts change.
+
 ---
 
 See also:
+- [Design System](../../DESIGN.md) — Full visual design reference
 - [Infrastructure](./02-infrastructure.md) — AWS and Cloudflare architecture
 - [Project Reference](../reference/01-project-reference.md) — Tech stack versions and commands

--- a/docs/how-to/01-development.md
+++ b/docs/how-to/01-development.md
@@ -49,6 +49,8 @@ Day-to-day development workflows, conventions, and tips for the VAIT Homepage.
   Use lazy loading and `React.memo` where appropriate.
 - **Accessibility:**
   Use semantic HTML and test with screen readers if possible. Aim for [WCAG 2.1](https://www.w3.org/WAI/WCAG21/quickref/) AA compliance.
+- **Visual / UI:**
+  Follow [DESIGN.md](../../DESIGN.md) for homepage colours, layout, and components. Add new brand tokens in `src/index.css` rather than inline hex in components.
 
 ---
 
@@ -56,3 +58,4 @@ See also:
 - [Getting Started](../tutorials/01-getting-started.md) — First-time setup
 - [Contributing](./02-contributing.md) — How to propose changes
 - [Project Reference](../reference/01-project-reference.md) — Commands and tech stack
+- [Design System](../../DESIGN.md) — Homepage visual design reference

--- a/docs/how-to/02-contributing.md
+++ b/docs/how-to/02-contributing.md
@@ -23,6 +23,7 @@ Thank you for your interest in contributing to the VAIT Homepage project!
 
 - New features, architectural changes, and configuration changes **must** include corresponding documentation updates.
 - The `docs/` directory follows the [Diataxis](https://diataxis.fr/) framework — place content in the correct category (tutorial, how-to, explanation, or reference).
+- Marketing UI changes (colours, typography, layout, new sections) **must** align with [DESIGN.md](../../DESIGN.md); update that file when tokens or documented components change.
 - Every mention of an external tool, framework, or standard must include a hyperlink on first mention per document.
 
 ## Where to Ask for Help
@@ -36,3 +37,4 @@ See also:
 - [Development](./01-development.md) — Day-to-day workflows and conventions
 - [Project Reference](../reference/01-project-reference.md) — Commands and tech stack
 - [Architecture](../explanation/01-architecture.md) — Design decisions
+- [Design System](../../DESIGN.md) — Homepage visual design reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,3 +20,4 @@ Welcome to the VAIT Homepage documentation, organised following the [Diataxis](h
 ## Reference
 
 - [Project Reference](./reference/01-project-reference.md) — Tech stack, commands, project structure, and testing tools
+- [Design System](../DESIGN.md) — Homepage visual design: colours, typography, components, and UI do's/don'ts

--- a/docs/reference/01-project-reference.md
+++ b/docs/reference/01-project-reference.md
@@ -42,7 +42,17 @@ public/        — Static assets
 .github/       — CI/CD workflows (GitHub Actions)
 docs/          — Project documentation (Diataxis framework)
 .agents/       — AI agent rules and skills
+DESIGN.md      — Homepage visual design system (see below)
+AGENTS.md      — AI agent control manifest
 ```
+
+## Design Documentation
+
+| Document | Purpose |
+|---|---|
+| [DESIGN.md](../../DESIGN.md) | Homepage visual design: colour tokens, typography, named components, layout, do's/don'ts |
+| [Architecture](../explanation/01-architecture.md) | Tech stack rationale and link to visual design |
+| Brand tokens in code | `src/index.css` (`--brand-*`), utilities in `@layer utilities` |
 
 ## Testing Tools
 


### PR DESCRIPTION
## Context

We need a single design-system reference for the VAIT landing page so UI changes stay consistent with brand yellow, warm backgrounds, and existing components. The Clay.com-style `DESIGN.md` format gives agents and contributors a skimmable contract (tokens, components, do's/don'ts) without reading every component file.

## Changes

- Add `DESIGN.md` at repo root documenting the current homepage aesthetic:
  - Overview, colours (brand + surfaces), typography hierarchy
  - Layout, elevation, border radius, and named components (`nav-bar`, `hero`, `content-shell`, etc.)
  - Do's and don'ts, responsive behaviour, iteration guide
  - Known gaps (no custom font, token naming drift, dark mode unused)

## Checklist

- [x] Documentation only — no runtime code changes
- [x] Pre-commit / push hooks passed locally
- [ ] Reviewers confirm tokens match intended brand direction (especially yellow vs logo hex)


Made with [Cursor](https://cursor.com)